### PR TITLE
Evict graph from cache upon config changes

### DIFF
--- a/docs/configuredgraphfactory.adoc
+++ b/docs/configuredgraphfactory.adoc
@@ -85,7 +85,7 @@ for which you have instantiated _and_ the references are stored inside the `Janu
 
 IMPORTANT: This is an irreversible operation that will delete all graph and index data.
 
-IMPORTANT: To ensure all graph representations are consistent across all JanusGraph nodes in your cluster, remove the graph from the `JanusGraphManager` graph reference tracker on all nodes in your cluster: `ConfiguredGraphFactory.close("graphName");`.
+IMPORTANT: To ensure all graph representations are consistent across all JanusGraph nodes in your cluster, this removes the graph from the `JanusGraphManager` graph cache on every node in the cluster, assuming each node has been properly configured to use the `JanusGraphManager`.
 
 [[configuring-JanusGraph-server-for-configuredgraphfactory]]
 === Configuring JanusGraph Server for ConfiguredGraphFactory
@@ -210,16 +210,7 @@ the property `graph.graphname` go through the `JanusGraphManager` which
 keeps track of graph references created on the given JVM. Think of it as
 a graph cache. For this reason:
 
-IMPORTANT: Any updates to a configuration are not guaranteed to take effect until
-you remove the graph in question on every JanusGraph node in your
-cluster.
-
-You can do so by calling:
-
-[source, gremlin]
-----
-ConfiguredGraphFactory.close("graph2");
-----
+IMPORTANT: Any updates to a graph configuration results in the eviction of the relevant graph from the graph cache on every node in the JanusGraph cluster, assuming each node has been configured properly to use the `JanusGraphManager`.
 
 Since graphs created using the template configuration first create a
 configuration for that graph in question using a copy and create method,
@@ -232,8 +223,7 @@ configuration are not guaranteed to take effect on the specific graph
 until:
 
 1. The relevant configuration is removed: `ConfiguredGraphFactory.removeConfiguration("graph2");`
-2. The graph in question has been closed on every JanusGraph node: `ConfiguredGraphFactory.close("graph2");`
-3. The graph is recreated using the template configuration: `ConfiguredGraphFactory.create("graph2");`
+2. The graph is recreated using the template configuration: `ConfiguredGraphFactory.create("graph2");`
 ====
 
 [[update-examples]]
@@ -259,9 +249,6 @@ map.put("storage.hostname", "10.0.0.1");
 ConfiguredGraphFactory.updateConfiguration("graph1",
 map);
 
-// Close graph
-ConfiguredGraphFactory.close("graph1");
-
 // We are now guaranteed to use the updated configuration
 def g1 = ConfiguredGraphFactory.open("graph1");
 ----
@@ -286,9 +273,6 @@ map.put("index.search.hostname", "127.0.0.1");
 map.put("index.search.elasticsearch.transport-scheme", "http");
 ConfiguredGraphFactory.updateConfiguration("graph1",
 map);
-
-// Close graph
-ConfiguredGraphFactory.close("graph1");
 
 // We are now guaranteed to use the updated configuration
 def g1 = ConfiguredGraphFactory.open("graph1");
@@ -316,9 +300,6 @@ MapConfiguration(map));
 
 // Remove Configuration
 ConfiguredGraphFactory.removeConfiguration("graph1");
-
-// Close graph on all JanusGraph nodes
-ConfiguredGraphFactory.close("graph1");
 
 // Recreate
 ConfiguredGraphFactory.create("graph1");

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1775,7 +1775,7 @@ public class GraphDatabaseConfiguration {
     }
 
     public String getGraphName() {
-        return getConfigurationAtOpen().getString(GRAPH_NAME.toString());
+        return getConfigurationAtOpen().getString(GRAPH_NAME.toStringWithoutRoot());
     }
 
     public StoreFeatures getStoreFeatures() {

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/GraphCacheEvictionAction.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/management/GraphCacheEvictionAction.java
@@ -1,0 +1,22 @@
+// Copyright 2018 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.database.management;
+
+public enum GraphCacheEvictionAction {
+
+    EVICT,
+    DO_NOT_EVICT
+}
+

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/database/serialize/StandardSerializer.java
@@ -28,6 +28,7 @@ import org.janusgraph.diskstorage.util.WriteByteBuffer;
 import org.janusgraph.diskstorage.util.time.TimestampProviders;
 import org.janusgraph.graphdb.database.idhandling.VariableLong;
 import org.janusgraph.graphdb.database.log.LogTxStatus;
+import org.janusgraph.graphdb.database.management.GraphCacheEvictionAction;
 import org.janusgraph.graphdb.database.management.MgmtLogType;
 import org.janusgraph.graphdb.database.serialize.attribute.*;
 import org.janusgraph.graphdb.internal.ElementCategory;
@@ -130,6 +131,7 @@ public class StandardSerializer implements AttributeHandler, Serializer {
         registerClassInternal(66,StandardTransactionId.class, new StandardTransactionIdSerializer());
         registerClassInternal(67,TraverserSet.class, new SerializableSerializer());
         registerClassInternal(68,HashMap.class, new SerializableSerializer());
+        registerClassInternal(69,GraphCacheEvictionAction.class, new EnumSerializer<>(GraphCacheEvictionAction.class));
 
     }
 

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/JanusGraphManager.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/management/JanusGraphManager.java
@@ -131,6 +131,11 @@ public class JanusGraphManager implements GraphManager {
         }
     }
 
+    // To be used for testing purposes
+    protected static void shutdownJanusGraphManager() {
+        instance = null;
+    }
+
     /**
      * @Deprecated
      */

--- a/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
+++ b/janusgraph-test/src/test/java/org/janusgraph/graphdb/management/ManagementLoggerGraphCacheEvictionTest.java
@@ -1,0 +1,78 @@
+// Copyright 2018 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.janusgraph.graphdb.management;
+
+import org.janusgraph.diskstorage.configuration.backend.CommonsConfiguration;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
+import org.janusgraph.graphdb.database.management.ManagementSystem;
+import org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.GRAPH_NAME;
+import static org.janusgraph.graphdb.configuration.GraphDatabaseConfiguration.STORAGE_BACKEND;
+
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.tinkerpop.gremlin.server.Settings;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ManagementLoggerGraphCacheEvictionTest {
+
+    @After
+    public void cleanUp() {
+        JanusGraphManager.shutdownJanusGraphManager();
+    }
+
+    @Test
+    public void shouldNotBeAbleToEvictGraphWhenJanusGraphManagerIsNull() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
+        final MapConfiguration config = new MapConfiguration(map);
+        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfiguration(new CommonsConfiguration(config)));
+        final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+        mgmt.evictGraphFromCache();
+        mgmt.commit();
+
+        assertNull(JanusGraphManager.getInstance());
+    }
+
+    @Test
+    public void graphShouldBeRemovedFromCache() throws InterruptedException {
+        final JanusGraphManager jgm = new JanusGraphManager(new Settings());
+        assertNotNull(jgm);
+        assertNotNull(JanusGraphManager.getInstance());
+        assertNull(jgm.getGraph("graph1"));
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put(STORAGE_BACKEND.toStringWithoutRoot(), "inmemory");
+        map.put(GRAPH_NAME.toStringWithoutRoot(), "graph1");
+        final MapConfiguration config = new MapConfiguration(map);
+        final StandardJanusGraph graph = new StandardJanusGraph(new GraphDatabaseConfiguration(new CommonsConfiguration(config)));
+        jgm.putGraph("graph1", graph);
+        assertEquals("graph1", ((StandardJanusGraph) JanusGraphManager.getInstance().getGraph("graph1")).getGraphName());
+
+        final ManagementSystem mgmt = (ManagementSystem) graph.openManagement();
+        mgmt.evictGraphFromCache();
+        mgmt.commit();
+
+        // wait for log to be asynchronously pulled
+        Thread.sleep(10000);
+
+        assertNull(jgm.getGraph("graph1"));
+    }
+}


### PR DESCRIPTION
When a graph configuration is updated or removed from the
ConfigurationGraphManagement, the related graph is evicted from the
cache on all JanusGraph nodes in the cluster. This is done to prevent
users from opening graphs with old/incorrect configurations across the
cluster and finding themselves in an inconsistent state. Note that this
is only done for users updating the ConfigurationManagementGraph by
going through the ConfiguredGraphFactory APIs; this is done for two
reasons: 1. to allow more fine-tuned control for users who wish to use
the lower-levls CMG APIs and 2. to avoid a cyclical dependency between
the CMG and the JanusGraphManager.

Issues: https://github.com/JanusGraph/janusgraph/issues/590

Signed-off-by: David Pitera <dpitera@us.ibm.com>
